### PR TITLE
Fix vulnerabilities: GO-2023-2382, GO-2023-2185

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,5 +17,5 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.4
+          go-version-input: 1.21.5
           go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alexandear/import-gitlab-commits
 
-go 1.21.4
+go 1.21.5
 
 require (
 	github.com/go-git/go-git/v5 v5.2.0


### PR DESCRIPTION
```sh
Run govulncheck -C . ./...
  govulncheck -C . ./...
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Scanning your code and 243 packages across 20 dependent modules for known vulnerabilities...

Vulnerability #1: GO-2023-2382
    Denial of service via chunk extensions in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2382
  Standard library
    Found in: net/http/internal@go1.21.4
    Fixed in: net/http/internal@go1.21.5
    Example traces found:
Error:       #1: internal/gitlab.go:31:50: internal.GitLab.CurrentUser calls gitlab.UsersService.CurrentUser, which eventually calls internal.chunkedReader.Read

Vulnerability #2: GO-2023-2185
    Insecure parsing of Windows paths with a \??\ prefix in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2185
  Standard library
    Found in: path/filepath@go1.21.4
    Fixed in: path/filepath@go1.21.5
    Platforms: windows
    Example traces found:
Error:       #1: internal/app.go:125:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls filepath.Abs
Error:       #2: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls filepath.Base
Error:       #3: internal/app.go:115:28: internal.App.createOrOpenRepo calls git.PlainInit, which eventually calls filepath.Clean
Error:       #4: internal/app.go:125:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls filepath.Dir
Error:       #5: internal/app.go:125:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls filepath.Join
Error:       #6: internal/app.go:115:28: internal.App.createOrOpenRepo calls git.PlainInit, which eventually calls filepath.Rel
Error:       #7: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls filepath.Split
Error:       #8: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls filepath.VolumeName
Error:       #9: internal/app.go:125:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls filepath.Abs
Error:       #10: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls filepath.Base
Error:       #11: internal/app.go:115:28: internal.App.createOrOpenRepo calls git.PlainInit, which eventually calls filepath.Clean
Error:       #12: internal/app.go:125:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls filepath.Dir
Error:       #13: internal/app.go:125:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls filepath.Join
Error:       #14: internal/app.go:115:28: internal.App.createOrOpenRepo calls git.PlainInit, which eventually calls filepath.Rel
Error:       #15: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls filepath.Split
Error:       #16: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls filepath.VolumeName

=== Informational ===

Found 3 vulnerabilities in packages that you import, but there are no call
stacks leading to the use of these vulnerabilities. You may not need to
take any action. See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
for details.

Vulnerability #1: GO-2022-0968
    Panic on malformed packets in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2022-0968
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20[200](https://github.com/alexandear/import-gitlab-commits/actions/runs/7167961840/job/19515098659#step:2:213)622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20211202192323-5770296d904e

Vulnerability #2: GO-2021-0356
    Denial of service via crafted Signer in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2021-0356
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20220314234659-1baeb1ce4c0b

Vulnerability #3: GO-2021-0227
    Panic on crafted authentication request message in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2021-0227
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20[201](https://github.com/alexandear/import-gitlab-commits/actions/runs/7167961840/job/19515098659#step:2:214)[216](https://github.com/alexandear/import-gitlab-commits/actions/runs/7167961840/job/19515098659#step:2:229)[223](https://github.com/alexandear/import-gitlab-commits/actions/runs/7167961840/job/19515098659#step:2:236)049-8b5274cf687f

Your code is affected by 2 vulnerabilities from the Go standard library.
```