### PR TITLE
Fix "cannot create empty commit: clean working tree"

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -185,8 +185,9 @@ func (a *App) doCommitsForProject(
 		committer.When = commit.CommittedAt
 
 		if _, errCommit := worktree.Commit(commit.Message, &git.CommitOptions{
-			Author:    committer,
-			Committer: committer,
+			Author:            committer,
+			Committer:         committer,
+			AllowEmptyCommits: true,
 		}); errCommit != nil {
 			return commitCounter, fmt.Errorf("commit: %w", errCommit)
 		}


### PR DESCRIPTION
The bug appeared after upgrading github.com/go-git/go-git to [v5.11.0](https://github.com/alexandear/import-gitlab-commits/pull/45).