### PR TITLE
Add support for multiple user emails

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -33,7 +33,7 @@ type App struct {
 
 type User struct {
 	Name      string
-	Email     string
+	Emails    []string
 	Username  string
 	CreatedAt time.Time
 }

--- a/internal/gitlab.go
+++ b/internal/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 

--- a/internal/gitlab.go
+++ b/internal/gitlab.go
@@ -33,15 +33,12 @@ func (s *GitLab) CurrentUser(ctx context.Context) (*User, error) {
 		return nil, fmt.Errorf("get current user: %w", err)
 	}
 
-	// Get the list of email addresses for the user.
 	emails, _, err := s.gitlabClient.Users.ListEmails(gitlab.WithContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("get user emails: %w", err)
 	}
 
-	// Extract email addresses from the response.
-	emailAddresses := make([]string, 0, 10)
-
+	emailAddresses := make([]string, 0, len(emails))
 	for _, email := range emails {
 		emailAddresses = append(emailAddresses, email.Email)
 	}
@@ -197,13 +194,9 @@ func (s *GitLab) fetchCommitPage(
 	return commits, resp.NextPage, nil
 }
 
-// Helper function to check if an email exists in the list.
-func contains(emails []string, email string) bool {
-	for _, e := range emails {
-		if strings.EqualFold(e, email) {
-			return true
-		}
-	}
-
-	return false
+// contains checks if a string `v` is in the slice `s`, ignoring case.
+func contains(s []string, v string) bool {
+	return slices.ContainsFunc(s, func(item string) bool {
+		return strings.EqualFold(item, v)
+	})
 }

--- a/internal/gitlab_test.go
+++ b/internal/gitlab_test.go
@@ -44,9 +44,18 @@ func newCurrentUser(t *testing.T, gitlabClient *gitlab.Client) *app.User {
 	user, _, err := gitlabClient.Users.CurrentUser()
 	require.NoError(t, err)
 
+	emails, _, err := gitlabClient.Users.ListEmails()
+	require.NoError(t, err)
+
+	emailAddresses := make([]string, 0, 10)
+
+	for _, email := range emails {
+		emailAddresses = append(emailAddresses, email.Email)
+	}
+
 	return &app.User{
 		Name:      user.Name,
-		Email:     user.Email,
+		Emails:    emailAddresses,
 		CreatedAt: *user.CreatedAt,
 	}
 }

--- a/internal/gitlab_test.go
+++ b/internal/gitlab_test.go
@@ -47,8 +47,7 @@ func newCurrentUser(t *testing.T, gitlabClient *gitlab.Client) *app.User {
 	emails, _, err := gitlabClient.Users.ListEmails()
 	require.NoError(t, err)
 
-	emailAddresses := make([]string, 0, 10)
-
+	emailAddresses := make([]string, 0, len(emails))
 	for _, email := range emails {
 		emailAddresses = append(emailAddresses, email.Email)
 	}


### PR DESCRIPTION
The code now fetches a list of user emails instead of a single email address per user. The user structure and corresponding parts of the code have been updated to handle and check multiple email addresses. Additionally, a helper function is added to check for the existence of an email in an email list.