### PR TITLE
Update fetchCommitPage to not specify Since

### DIFF
--- a/internal/gitlab.go
+++ b/internal/gitlab.go
@@ -119,10 +119,6 @@ func (s *GitLab) FetchCommits(ctx context.Context, user *User, projectID int, si
 ) ([]*Commit, error) {
 	commits := make([]*Commit, 0, maxCommits)
 
-	if since.IsZero() {
-		since = user.CreatedAt
-	}
-
 	page := 1
 	for page > 0 {
 		cms, nextPage, err := s.fetchCommitPage(ctx, user, page, 100, since, projectID)
@@ -152,8 +148,11 @@ func (s *GitLab) fetchCommitPage(
 			PerPage: perPage,
 			Page:    page,
 		},
-		Since: gitlab.Time(since),
-		All:   gitlab.Bool(true),
+		All: gitlab.Bool(true),
+	}
+
+	if !since.IsZero() {
+		opt.Since = gitlab.Time(since)
 	}
 
 	comms, resp, err := s.gitlabClient.Commits.ListCommits(projectID, opt, gitlab.WithContext(ctx))


### PR DESCRIPTION
In its previous state, fetchCommitPage checked for commits solely from the point at which the user joined a specific GitLab instance during the initial load. This amendment uses a check of the entire commit history.

Use case:

We have migrated from a public GitLab.com to a privately hosted Gitlab instance. Therefore, the users are newer than most of their commit history.

This does change the behavior of the importer, so not sure if it should be accepted.