### PR TITLE
Fix vulnerabilities: GO-2024-2598,GO-2024-2599,GO-2024-2600

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,5 +17,5 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.5
+          go-version-input: 1.21.8
           go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alexandear/import-gitlab-commits
 
-go 1.21.5
+go 1.21.8
 
 require (
 	github.com/go-git/go-git/v5 v5.11.0


### PR DESCRIPTION
The PR fixes the following `govulncheck` issues:
```
=== Symbol Results ===

Vulnerability #1: GO-2024-2600
    Incorrect forwarding of sensitive headers and cookies on HTTP redirect in
    net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2600
  Standard library
    Found in: net/http@go1.21.5
    Fixed in: net/http@go1.21.8
    Example traces found:
Error:       #1: internal/gitlab.go:37:51: internal.GitLab.CurrentUser calls gitlab.UsersService.ListEmails, which eventually calls http.Client.Do

Vulnerability #2: GO-2024-2599
    Memory exhaustion in multipart form parsing in net/textproto and net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2599
  Standard library
    Found in: net/textproto@go1.21.5
    Fixed in: net/textproto@go1.21.8
    Example traces found:
Error:       #1: internal/gitlab.go:37:51: internal.GitLab.CurrentUser calls gitlab.UsersService.ListEmails, which eventually calls textproto.Reader.ReadLine
Error:       #2: internal/gitlab.go:37:51: internal.GitLab.CurrentUser calls gitlab.UsersService.ListEmails, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #3: GO-2024-2598
    Verify panics on certificates with an unknown public key algorithm in
    crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2024-2598
  Standard library
    Found in: crypto/x509@go1.21.5
    Fixed in: crypto/x509@go1.21.8
    Example traces found:
Error:       #1: internal/gitlab.go:37:51: internal.GitLab.CurrentUser calls gitlab.UsersService.ListEmails, which eventually calls x509.Certificate.Verify
```