### PR TITLE
Use the latest minor Go version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,5 +17,6 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
+          check-latest: true
           go-version-file: go.mod
           go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alexandear/import-gitlab-commits
 
-go 1.22.2
+go 1.22
 
 require (
 	github.com/go-git/go-git/v5 v5.11.0


### PR DESCRIPTION
This fixes `govulncheck` error:
```
Scanning your code and 285 packages across 26 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2824
    Malformed DNS message can cause infinite loop in net
  More info: https://pkg.go.dev/vuln/GO-2024-2824
  Standard library
    Found in: net@go1.22.2
    Fixed in: net@go1.22.3
    Example traces found:
Error:       #1: internal/gitlab.go:37:51: internal.GitLab.CurrentUser calls gitlab.UsersService.ListEmails, which eventually calls net.Dialer.DialContext

Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 2
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```