### PR TITLE
Setup automatic updates for golangci-lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      day: "sunday"
-      time: "11:00"
+  - package-ecosystem: gomod
+    directory: "/tools"
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  GOLANGCI_LINT_VERSION: v1.57.2
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -22,7 +19,11 @@ jobs:
           go-version: 'stable'
           check-latest: true
 
+      - id: golangci-lint-version
+        run: |
+          make gh-lint-version >> $GITHUB_OUTPUT
+
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          version: ${{ steps.golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
           args: --verbose --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GOBIN := $(MAKEFILE_PATH)/bin
 
 PATH := $(GOBIN):$(PATH)
 
-GOLANGCI_LINT_VERSION=$(shell awk '/GOLANGCI_LINT_VERSION:/ { print $$2 }' .github/workflows/lint.yml)
+GOLANGCI_LINT_VERSION ?= $(shell cd tools; go list -m -f '{{.Version}}' github.com/golangci/golangci-lint)
 
 .PHONY: all
 all: clean format build lint test
@@ -35,6 +35,10 @@ lint:
 	@echo lint
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@$(GOBIN)/golangci-lint run
+
+.PHONY: gh-lint-version
+gh-lint-version:
+	@echo "GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION)"
 
 .PHONY: format
 format:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,5 @@
+module github.com/alexandear/import-gitlab-commits/tools
+
+go 1.22
+
+require github.com/golangci/golangci-lint v1.57.2

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,0 +1,2 @@
+github.com/golangci/golangci-lint v1.57.2 h1:NNhxfZyL5He1WWDrIvl1a4n5bvWZBcgAqBwlJAAgLTw=
+github.com/golangci/golangci-lint v1.57.2/go.mod h1:ApiG3S3Ca23QyfGp5BmsorTiVxJpr5jGiNS0BkdSidg=

--- a/tools/pinversion.go
+++ b/tools/pinversion.go
@@ -1,0 +1,8 @@
+//go:build tools
+
+package tools
+
+// Keep a reference to the code generators so they are not removed by go mod tidy
+import (
+	_ "github.com/golangci/golangci-lint/pkg/exitcodes"
+)


### PR DESCRIPTION
The approach borrowed from the `kubernetes-sigs/kueue` project. See
- https://github.com/kubernetes-sigs/kueue/blob/aeb13cf6b1733f578b2e301b2d506e13e4776285/Makefile-deps.mk#L29
- https://github.com/kubernetes-sigs/kueue/blob/aeb13cf6b1733f578b2e301b2d506e13e4776285/hack/internal/tools/pinversion.go#L26