### PR TITLE
Remove 'check-latest' from setup-go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-          check-latest: true
 
       - run: go mod tidy && git diff --exit-code
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-          check-latest: true
 
       - id: golangci-lint-version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-          check-latest: true
 
       - run: go test -v -count=1 -race -shuffle=on -cover ./...
 


### PR DESCRIPTION
The PR fixes: `Warning: Both go-version and go-version-file inputs are specified, only go-version will be used`

<img width="887" alt="image" src="https://github.com/user-attachments/assets/c5f06cf6-1cee-4513-8ab2-6923908eafcd" />
