### PR TITLE
Avoid govulncheck warning about go-version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,5 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          check-latest: true
           go-version-file: go.mod
           go-package: ./...


### PR DESCRIPTION
The PR fixes: `Warning: Both go-version and go-version-file inputs are specified, only go-version will be used`

<img width="887" alt="image" src="https://github.com/user-attachments/assets/c5f06cf6-1cee-4513-8ab2-6923908eafcd" />
