### PR TITLE
Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  MAKEFLAGS: --no-print-directory
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           make gh-lint-version >> $GITHUB_OUTPUT
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ steps.golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
           args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,68 +1,177 @@
+version: "2"
 run:
-  concurrency: 8
   issues-exit-code: 1
   tests: true
-
-linters-settings:
-  decorder:
-    dec-order:
-      - const
-      - type
-      - var
-      - func
-    disable-dec-order-check: false
-    disable-init-func-first-check: false
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/alexandear/import-gitlab-commits)
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  gocognit:
-    min-complexity: 15
-  gocyclo:
-    min-complexity: 10
-  godot:
-    scope: all
-    capital: true
-  gofumpt:
-    extra-rules: true
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  usetesting:
-    context-background: true
-    context-todo: true
-    os-chdir: true
-    os-mkdir-temp: true
-    os-setenv: true
-    os-create-temp: true
-    os-temp-dir: true
-
 linters:
-  enable-all: true
+  default: all
   disable:
     - depguard
     - err113
     - exhaustruct
-    - gomnd
+    - mnd
     - nonamedreturns
     - paralleltest
     - rowserrcheck
-    - tenv
-    - testpackage
     - wastedassign
+  settings:
+    decorder:
+      dec-order:
+        - const
+        - type
+        - var
+        - func
+      disable-dec-order-check: false
+      disable-init-func-first-check: false
+    gocognit:
+      min-complexity: 15
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enable-all: true
+    gocyclo:
+      min-complexity: 10
+    godot:
+      scope: all
+      capital: true
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    revive:
+      # Set below 0.8 to enable error-strings
+      confidence: 0.6
+      rules:
+        - name: add-constant
+          disabled: true
+        - name: argument-limit
+        - name: atomic
+        - name: banned-characters
+        - name: bare-return
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: comment-spacings
+        - name: confusing-naming
+        - name: confusing-results
+        - name: constant-logical-expr
+        - name: context-as-argument
+          arguments:
+            # allow functions with signature: func foo(t *testing.T, ctx context.Context)
+            - allowTypesBefore: "*testing.T"
+        - name: context-keys-type
+        - name: datarace
+        - name: deep-exit
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: empty-lines
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: enforce-map-style
+        - name: enforce-repeated-arg-type-style
+        - name: enforce-slice-style
+        - name: exported
+        - name: file-header
+        - name: file-length-limit
+        - name: filename-format
+          arguments:
+            - "^[_a-z][_a-z0-9]*.go$"
+        - name: flag-parameter
+        - name: function-length
+        - name: function-result-limit
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: import-alias-naming
+        - name: import-shadowing
+        - name: imports-blocklist
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: line-length-limit
+          arguments:
+            - 120
+        - name: max-control-nesting
+        - name: max-public-structs
+        - name: modifies-parameter
+        - name: modifies-value-receiver
+        - name: nested-structs
+        - name: optimize-operands-order
+        - name: package-comments
+        - name: range-val-address
+        - name: range-val-in-closure
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: redundant-build-tag
+        - name: redundant-import-alias
+        - name: string-format
+        - name: string-of-int
+        - name: struct-tag
+          arguments:
+            - "json,inline"
+        - name: superfluous-else
+        - name: time-equal
+        - name: time-naming
+        - name: unchecked-type-assertion
+        - name: unconditional-recursion
+        - name: unexported-naming
+        - name: unexported-return
+        - name: unhandled-error
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: unused-receiver
+        - name: use-any
+        - name: use-errors-new
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+        - name: waitgroup-by-value
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-chdir: true
+      os-mkdir-temp: true
+      os-setenv: true
+      os-temp-dir: true
+      os-create-temp: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/alexandear/import-gitlab-commits)
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GOBIN := $(MAKEFILE_PATH)/bin
 
 PATH := $(GOBIN):$(PATH)
 
-GOLANGCI_LINT_VERSION ?= $(shell cd tools; go list -m -f '{{.Version}}' github.com/golangci/golangci-lint)
+GOLANGCI_LINT_VERSION ?= $(shell $(MAKE) -C tools golangci-lint-version)
 
 .PHONY: all
 all: clean format build lint test
@@ -30,11 +30,17 @@ test-integration:
 	@echo test-integration
 	@go test -tags=integration -run=TestGitLab -shuffle=on -count=1 -race -v ./...
 
+.PHONY: golangci-lint-version
+golangci-lint-version:
+	@echo golangci-lint version $(GOLANGCI_LINT_VERSION)
+
 .PHONY: lint
-lint:
+lint: golangci-lint-version $(GOBIN)/golangci-lint
 	@echo lint
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@$(GOBIN)/golangci-lint run
+
+$(GOBIN)/golangci-lint:
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(GOBIN)" "$(GOLANGCI_LINT_VERSION)"
 
 .PHONY: gh-lint-version
 gh-lint-version:

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,8 @@ test-integration:
 	@echo test-integration
 	@go test -tags=integration -run=TestGitLab -shuffle=on -count=1 -race -v ./...
 
-.PHONY: golangci-lint-version
-golangci-lint-version:
-	@echo golangci-lint version $(GOLANGCI_LINT_VERSION)
-
 .PHONY: lint
-lint: golangci-lint-version $(GOBIN)/golangci-lint
+lint: gh-lint-version $(GOBIN)/golangci-lint
 	@echo lint
 	@$(GOBIN)/golangci-lint run
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	goGitlab "github.com/xanzy/go-gitlab"
+	gogitlab "github.com/xanzy/go-gitlab"
 )
 
 const (
@@ -40,7 +40,7 @@ type User struct {
 
 func New(logger *log.Logger, gitlabToken string, gitlabBaseURL *url.URL, committerName, committerEmail string,
 ) (*App, error) {
-	gitlabClient, err := goGitlab.NewClient(gitlabToken, goGitlab.WithBaseURL(gitlabBaseURL.String()))
+	gitlabClient, err := gogitlab.NewClient(gitlabToken, gogitlab.WithBaseURL(gitlabBaseURL.String()))
 	if err != nil {
 		return nil, fmt.Errorf("create GitLab client: %w", err)
 	}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,3 @@
+.PHONY: golangci-lint-version
+golangci-lint-version:
+	@go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/alexandear/import-gitlab-commits/tools
 
-go 1.22
+go 1.23.0
+
 toolchain go1.24.1
 
-require github.com/golangci/golangci-lint v1.64.8
+require github.com/golangci/golangci-lint/v2 v2.0.2

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,2 +1,2 @@
-github.com/golangci/golangci-lint v1.64.8 h1:y5TdeVidMtBGG32zgSC7ZXTFNHrsJkDnpO4ItB3Am+I=
-github.com/golangci/golangci-lint v1.64.8/go.mod h1:5cEsUQBSr6zi8XI8OjmcY2Xmliqc4iYL7YoPrL+zLJ4=
+github.com/golangci/golangci-lint/v2 v2.0.2 h1:dMCC8ikPiLDvHMFy3+XypSAuGDBOLzwWqqamer+bWsY=
+github.com/golangci/golangci-lint/v2 v2.0.2/go.mod h1:ptNNMeGBQrbves0Qq38xvfdJg18PzxmT+7KRCOpm6i8=

--- a/tools/pinversion.go
+++ b/tools/pinversion.go
@@ -4,5 +4,5 @@ package tools
 
 // Keep a reference to the code generators so they are not removed by go mod tidy
 import (
-	_ "github.com/golangci/golangci-lint/pkg/exitcodes"
+	_ "github.com/golangci/golangci-lint/v2/pkg/exitcodes"
 )


### PR DESCRIPTION
Use the command `golangci-lint migrate` to upgrade configuration.