### PR TITLE
Use fallback email if ListEmails fails

### DIFF
--- a/internal/gitlab.go
+++ b/internal/gitlab.go
@@ -44,6 +44,11 @@ func (s *GitLab) CurrentUser(ctx context.Context) (*User, error) {
 		emailAddresses = append(emailAddresses, email.Email)
 	}
 
+	if len(emailAddresses) == 0 {
+		log.Printf("No emails returned from ListEmails; using fallback user.Email: %s", user.Email)
+		emailAddresses = []string{user.Email}
+	}
+
 	return &User{
 		Name:      user.Name,
 		Emails:    emailAddresses,


### PR DESCRIPTION
I found that in the gitlab.go theres a CurrentUser function, which uses ListEmails which in turn wasn't returning any email. I added a fallback email taken from user.Email if the emails list is empty.

Fixes #121
