### PR TITLE
Fix vulnerability: GO-2025-3754

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alexandear/import-gitlab-commits
 
-go 1.22
+go 1.24.0
 
 require (
 	github.com/go-git/go-git/v5 v5.13.1
@@ -12,7 +12,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.3.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cyphar/filepath-securejoin v0.3.6 h1:4d9N5ykBnSp5Xn2JkhocYDkOpURL/18CYMpo6xB9uWM=
 github.com/cyphar/filepath-securejoin v0.3.6/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
```console
$ go run golang.org/x/vuln/cmd/govulncheck@latest ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-3754
    CIRCL-Fourq: Missing and wrong validation can lead to incorrect results in
    github.com/cloudflare/circl
  More info: https://pkg.go.dev/vuln/GO-2025-3754
  Module: github.com/cloudflare/circl
    Found in: github.com/cloudflare/circl@v1.3.7
    Fixed in: github.com/cloudflare/circl@v1.6.1
    Example traces found:
      #1: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls conv.BytesLe2BigInt
      #2: internal/app.go:14:2: internal.init calls object.init, which eventually calls conv.init
      #3: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls ed25519.Sign
      #4: internal/app.go:14:2: internal.init calls object.init, which eventually calls ed25519.init
      #5: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls ed448.Sign
      #6: internal/app.go:14:2: internal.init calls object.init, which eventually calls ed448.init
      #7: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Add
      #8: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Cmov
      #9: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Cswap
      #10: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Inv
      #11: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Modp
      #12: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Mul
      #13: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Neg
      #14: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.SetOne
      #15: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Sqr
      #16: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.Sub
      #17: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp25519.ToBytes
      #18: internal/app.go:14:2: internal.init calls object.init, which eventually calls fp25519.init
      #19: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Add
      #20: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Cmov
      #21: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Cswap
      #22: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Inv
      #23: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Modp
      #24: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Mul
      #25: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Neg
      #26: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.One
      #27: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.SetOne
      #28: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Sqr
      #29: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.Sub
      #30: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls fp448.ToBytes
      #31: internal/app.go:14:2: internal.init calls object.init, which eventually calls fp448.init
      #32: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls goldilocks.Curve.ScalarBaseMult
      #33: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls goldilocks.Point.ToBytes
      #34: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls goldilocks.Scalar.Add
      #35: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls goldilocks.Scalar.FromBytes
      #36: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls goldilocks.Scalar.Mul
      #37: internal/app.go:14:2: internal.init calls object.init, which eventually calls goldilocks.init
      #38: internal/app.go:14:2: internal.init calls object.init, which eventually calls math.init
      #39: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls mlsbset.Encoder.Encode
      #40: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls mlsbset.Encoder.IsExtended
      #41: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls mlsbset.New
      #42: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls mlsbset.Power.Exp
      #43: internal/app.go:14:2: internal.init calls object.init, which eventually calls mlsbset.init
      #44: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls sha3.NewShake256
      #45: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls sha3.State.Read
      #46: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls sha3.State.Reset
      #47: internal/app.go:187:37: internal.App.doCommitsForProject calls git.Worktree.Commit, which eventually calls sha3.State.Write
      #48: internal/app.go:14:2: internal.init calls object.init, which eventually calls sha3.init
      #49: internal/app.go:14:2: internal.init calls object.init, which eventually calls sign.init
      #50: internal/app.go:14:2: internal.init calls object.init, which eventually calls x25519.init
      #51: internal/app.go:14:2: internal.init calls object.init, which eventually calls x448.init

Your code is affected by 1 vulnerability from 1 module.
This scan also found 2 vulnerabilities in packages you import and 2
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
exit status 3
```