### PR TITLE
Pass secrets for PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
   test:


### PR DESCRIPTION
`pull_request_target` event runs in the context of the base repository (not the fork).