### PR TITLE
Simplify mod tidy GHA step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           check-latest: true
 
       - working-directory: tools
-        run: go mod tidy && git diff --exit-code
+        run: go mod tidy -diff
 
       - id: golangci-lint-version
         working-directory: tools


### PR DESCRIPTION
```console
$ go mod tidy help
...
The -diff flag causes tidy not to modify go.mod or go.sum but
instead print the necessary changes as a unified diff. It exits
with a non-zero code if the diff is not empty.
```