### PR TITLE
Fix zizmor issues in GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
       - "/tools"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,25 @@ on:
   schedule:
     - cron: '0 8 1 * *' # run "At 08:00 on day-of-month 1"
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
           check-latest: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - run: go mod tidy -diff
 
@@ -36,9 +41,11 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - run: docker build --progress=plain -t github.com/alexandear/import-gitlab-commits:ci .
 

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: 14
           days-before-close: 14

--- a/.github/workflows/depreview.yml
+++ b/.github/workflows/depreview.yml
@@ -12,6 +12,8 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,15 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
           check-latest: true
@@ -27,7 +32,7 @@ jobs:
         run: |
           echo "GOLANGCI_LINT_VERSION=$(go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)" >> $GITHUB_OUTPUT
 
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: ${{ steps.golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
           args: --verbose

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,10 +9,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   vulncheck:
     name: Scan for vulnerabilities in Go code
     runs-on: ubuntu-latest
     steps:
       - name: govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,11 @@ name: Test
 on:
   push:
     branches: [main]
-  pull_request_target:
-    types: [opened, synchronize]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -16,9 +19,11 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         GITLAB_BASE_URL: https://gitlab.com
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
           check-latest: true


### PR DESCRIPTION
```console
❯ zizmor .github | pbcopy
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> .github/dependabot.yml:3:5
  |
3 |   - package-ecosystem: gomod
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
  |
  = note: audit confidence → High
  = note: this finding has an auto-fix
  = help: audit documentation → https://docs.zizmor.sh/audits/#dependabot-cooldown

warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> .github/dependabot.yml:9:5
  |
9 |   - package-ecosystem: github-actions
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
  |
  = note: audit confidence → High
  = note: this finding has an auto-fix
  = help: audit documentation → https://docs.zizmor.sh/audits/#dependabot-cooldown

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/build.yml:17:9
   |
17 |       - uses: actions/checkout@v6
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/build.yml:39:9
   |
39 |       - uses: actions/checkout@v6
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/build.yml:1:1
   |
 1 | / name: Build
 2 | |
 3 | | on:
 4 | |   push:
...  |
46 | |         run: |
47 | |           docker run --rm github.com/alexandear/import-gitlab-commits:ci --help
   | |________________________________________________________________________________^ default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium
   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/build.yml:12:3
   |
12 | /   run:
13 | |     runs-on: ubuntu-latest
14 | |     timeout-minutes: 5
...  |
32 | |       - run: go build -o /dev/null ./...
   | |                                        ^
   | |                                        |
   | |________________________________________this job
   |                                          default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium
   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/build.yml:34:3
   |
34 | /   docker:
35 | |     runs-on: ubuntu-latest
36 | |     timeout-minutes: 5
...  |
46 | |         run: |
47 | |           docker run --rm github.com/alexandear/import-gitlab-commits:ci --help
   | |                                                                                ^
   | |                                                                                |
   | |________________________________________________________________________________this job
   |                                                                                  default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium
   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build.yml:17:15
   |
17 |       - uses: actions/checkout@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build.yml:19:15
   |
19 |       - uses: actions/setup-go@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build.yml:24:15
   |
24 |       - uses: docker/setup-buildx-action@v4
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build.yml:39:15
   |
39 |       - uses: actions/checkout@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build.yml:41:15
   |
41 |       - uses: docker/setup-buildx-action@v4
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/close-stale-issues.yml:18:15
   |
18 |       - uses: actions/stale@v10
   |               ^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/depreview.yml:15:9
   |
15 |       - uses: actions/checkout@v6
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/depreview.yml:15:15
   |
15 |       - uses: actions/checkout@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/depreview.yml:17:15
   |
17 |       - uses: actions/dependency-review-action@v4
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/lint.yml:15:9
   |
15 |       - uses: actions/checkout@v6
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/lint.yml:10:3
   |
10 | /   lint:
11 | |     runs-on: ubuntu-latest
12 | |     timeout-minutes: 5
...  |
32 | |           version: ${{ steps.golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
33 | |           args: --verbose
   | |                          ^
   | |                          |
   | |__________________________this job
   |                            default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium
   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/lint.yml:15:15
   |
15 |       - uses: actions/checkout@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/lint.yml:17:15
   |
17 |       - uses: actions/setup-go@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/lint.yml:30:15
   |
30 |       - uses: golangci/golangci-lint-action@v9
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/security.yml:13:3
   |
13 | /   vulncheck:
14 | |     name: Scan for vulnerabilities in Go code
15 | |     runs-on: ubuntu-latest
16 | |     steps:
17 | |       - name: govulncheck
18 | |         uses: golang/govulncheck-action@v1
   | |                                           ^
   | |                                           |
   | |___________________________________________this job
   |                                             default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium
   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/security.yml:18:15
   |
18 |         uses: golang/govulncheck-action@v1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:19:9
   |
19 |       - uses: actions/checkout@v6
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/test.yml:10:3
   |
10 | /   test:
11 | |     runs-on: ubuntu-latest
12 | |     timeout-minutes: 5
13 | |     env:
...  |
37 | |       - name: Integration tests
38 | |         run: go test -tags=integration -run=TestGitLab -shuffle=on -count=1 -race -v ./...
   | |                                                                                           ^
   | |                                                                                           |
   | |___________________________________________________________________________________________this job
   |                                                                                             default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium
   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> .github/workflows/test.yml:3:1
  |
3 | / on:
4 | |   push:
5 | |     branches: [main]
6 | |   pull_request_target:
7 | |     types: [opened, synchronize]
  | |________________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium
  = help: audit documentation → https://docs.zizmor.sh/audits/#dangerous-triggers

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/test.yml:19:15
   |
19 |       - uses: actions/checkout@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/test.yml:21:15
   |
21 |       - uses: actions/setup-go@v6
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

46 findings (18 suppressed, 2 safe fixes, 5 unsafe fixes): 0 informational, 5 low, 8 medium, 15 high

```