### PR TITLE
Update lint config by adding integration build tag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ version: "2"
 run:
   issues-exit-code: 1
   tests: true
+  build-tags:
+    - integration
 linters:
   default: all
   disable:

--- a/internal/gitlab_test.go
+++ b/internal/gitlab_test.go
@@ -3,13 +3,12 @@
 package app_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gitlab.com/gitlab-org/api/client-go"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 
 	app "github.com/alexandear/import-gitlab-commits/internal"
 	"github.com/alexandear/import-gitlab-commits/internal/testutil"
@@ -18,7 +17,7 @@ import (
 func TestGitLabCurrentUser(t *testing.T) {
 	gl := app.NewGitLab(testutil.NewLog(t), gitlabClient(t))
 
-	user, err := gl.CurrentUser(context.Background())
+	user, err := gl.CurrentUser(t.Context())
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, user.Name)


### PR DESCRIPTION
```
❯ golangci-lint run ./...
internal/gitlab_test.go:21:30: context.Background() could be replaced by t.Context() in TestGitLabCurrentUser (usetesting)
        user, err := gl.CurrentUser(context.Background())
                                    ^
1 issues:
* usetesting: 1
```