### PR TITLE
Use stable version for govulncheck

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,3 +19,5 @@ jobs:
     steps:
       - name: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: stable


### PR DESCRIPTION
```
go version go1.26.3 linux/amd64

go env
Run go install golang.org/x/vuln/cmd/govulncheck@latest
go: downloading golang.org/x/vuln v1.3.0
go: downloading golang.org/x/telemetry v0.0.0-20260421165255-392afab6f40e
go: downloading golang.org/x/mod v0.35.0
go: downloading golang.org/x/tools v0.44.0
go: downloading golang.org/x/sync v0.20.0
Run govulncheck -C . -format text ./...
  govulncheck -C . -format text ./...
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
=== Symbol Results ===

Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.26.3
    Fixed in: net/textproto@go1.26.4
    Example traces found:
Error:       #1: internal/app.go:127:28: internal.App.createOrOpenRepo calls git.PlainOpen, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #2: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.26.3
    Fixed in: crypto/x509@go1.26.4
    Example traces found:
Error:       #1: internal/gitlab.go:78:58: internal.GitLab.FetchProjectPage calls client.ProjectsService.ListProjects, which eventually calls x509.Certificate.Verify
Error:       #2: internal/gitlab.go:78:58: internal.GitLab.FetchProjectPage calls client.ProjectsService.ListProjects, which eventually calls x509.Certificate.VerifyHostname
Error:       #3: internal/commit.go:18:27: internal.NewCommit calls fmt.Sprintf, which eventually calls x509.HostnameError.Error

Your code is affected by 2 vulnerabilities from the Go standard library.
This scan also found 14 vulnerabilities in packages you import and 8
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```